### PR TITLE
Get default TX port for UART from HardwareSerial

### DIFF
--- a/src/TJA1020.cpp
+++ b/src/TJA1020.cpp
@@ -19,7 +19,7 @@
 /// Provides HW UART via TJA1020 Chip
 Lin_TJA1020::Lin_TJA1020(int uart_nr, uint32_t _baud, int8_t nslpPin) : Lin_Interface(uart_nr)
 {
-    //  use default baud rate, if not specified
+    // use default baud rate, if not specified
     Lin_Interface::baud = _baud ? _baud : 19200;
 
     // Retrieve the default UART RX and TX pins

--- a/src/TJA1020.hpp
+++ b/src/TJA1020.hpp
@@ -37,6 +37,5 @@ public:
 private:
     TJA1020_Mode _writingSlope = NormalSlope;
     TJA1020_Mode _currentMode = Sleep;
-    int8_t _tx_pin;
     int8_t _nslp_pin;
 };


### PR DESCRIPTION
As I am using a Heltec ESP32 Lora v3 board, all default UART 0, 1, 2 TX and/or RX pins are in use. Setting them for Lin_Interface is easy, but the Lin_TJA1020 did not notice this and was actually hard coded. The ESP32-S3 on my board also has different default pins.

I found a way to retrieve them from HardwareSerial, but they are only set between the begin and end functions. I can't test for ESP8266 but for ESP32 it works with the latest PlatformIO libraries.